### PR TITLE
Migrate flutter 1.20 fix android

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/XPlatformPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/XPlatformPlugin.java
@@ -84,6 +84,11 @@ public class XPlatformPlugin {
             XPlatformPlugin.this.setClipboardData(text);
         }
 
+        @Override
+        public boolean clipboardHasStrings()() {
+            return XPlatformPlugin.this.clipboardHasStrings();
+        }
+
 //        @Override
 //        public List<Rect> getSystemGestureExclusionRects() {
 //            return XPlatformPlugin.this.getSystemGestureExclusionRects();
@@ -285,6 +290,17 @@ public class XPlatformPlugin {
         ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
         ClipData clip = ClipData.newPlainText("text label?", text);
         clipboard.setPrimaryClip(clip);
+    }
+
+    private boolean clipboardHasStrings() {
+        ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+        ClipData clip = clipboard.getPrimaryClip();
+        ClipData.Item item = clip.getItemAt(0);
+        if(item != null && item.getText() != null && item.getText().toString() != null){
+            return true;
+        }else {
+            return false;
+        }
     }
 
 

--- a/android/src/main/java/com/idlefish/flutterboost/XPlatformPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/XPlatformPlugin.java
@@ -85,7 +85,7 @@ public class XPlatformPlugin {
         }
 
         @Override
-        public boolean clipboardHasStrings()() {
+        public boolean clipboardHasStrings() {
             return XPlatformPlugin.this.clipboardHasStrings();
         }
 

--- a/android/src/main/java/com/idlefish/flutterboost/XTextInputPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/XTextInputPlugin.java
@@ -98,6 +98,12 @@ public class XTextInputPlugin {
             public void clearClient() {
                 clearTextInputClient();
             }
+
+            @Override
+            public void sendAppPrivateCommand(String action, Bundle data) {
+                
+            }
+
         });
     }
 

--- a/android/src/main/java/com/idlefish/flutterboost/XTextInputPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/XTextInputPlugin.java
@@ -7,7 +7,7 @@ import android.text.Editable;
 import android.text.InputType;
 import android.text.Selection;
 import android.view.View;
-import android.os.Bundle
+import android.os.Bundle;
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;

--- a/android/src/main/java/com/idlefish/flutterboost/XTextInputPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/XTextInputPlugin.java
@@ -7,6 +7,7 @@ import android.text.Editable;
 import android.text.InputType;
 import android.text.Selection;
 import android.view.View;
+import android.os.Bundle
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
@@ -101,6 +102,11 @@ public class XTextInputPlugin {
 
             @Override
             public void sendAppPrivateCommand(String action, Bundle data) {
+                
+            }
+
+            @Override
+            public void finishAutofillContext(boolean shouldSave) {
                 
             }
 


### PR DESCRIPTION
修复了在Android上因XTextInputPlugin不是抽象的, 并且未覆盖TextInputMethodHandler中的抽象方法的错误而无法编译的问题